### PR TITLE
Added IGNORE_DIRS option

### DIFF
--- a/makeEspArduino.mk
+++ b/makeEspArduino.mk
@@ -142,8 +142,14 @@ ifeq ($(LIBS),)
 endif
 
 SKETCH_DIR = $(dir $(SKETCH))
-USER_INC := $(shell find $(SKETCH_DIR) $(LIBS) -name "*.h")
-USER_SRC := $(SKETCH) $(shell find $(SKETCH_DIR) $(LIBS) -name "*.S" -o -name "*.c" -o -name "*.cpp")
+
+SHELL := /bin/bash
+ifdef IGNORE_DIRS
+  EXCLUDE := $(shell IFS=';' read -ra ADDR <<< "$(IGNORE_DIRS)" ; for i in "$${ADDR[@]}"; do if [ ! -z "$$i" ]; then s="$${s} -not -path '$${i}'"; fi done; echo $$s)
+endif
+
+USER_INC := $(shell find $(SKETCH_DIR) $(LIBS) -name "*.h" $(EXCLUDE) )
+USER_SRC := $(SKETCH) $(shell find $(SKETCH_DIR) $(LIBS) -name "*.S" -o -name "*.c" -o -name "*.cpp" $(EXCLUDE) )
 # Object file suffix seems to be significant for the linker...
 USER_OBJ := $(subst .ino,_.cpp,$(patsubst %,$(BUILD_DIR)/%$(OBJ_EXT),$(notdir $(USER_SRC))))
 USER_DIRS := $(sort $(dir $(USER_SRC)))


### PR DESCRIPTION
In project Makefile I can ignore some directories from discovering source files. 

I had this use case:
```bash
ls
> libraries  project.ino  Makefile
git submodule add https://github.com/knolleary/pubsubclient.git libraries/pubsubclient
make
> 
/project/libraries/pubsubclient/tests/src/receive_spec.cpp: In function 'int test_receive_stream()':
/project/libraries/pubsubclient/tests/src/receive_spec.cpp:64:12: error: cannot declare variable 'stream' to be of abstract type 'Stream'
     Stream stream;
            ^
```
I dont want to compile directory tests in pubsubclient library.

With added IGNORE_DIRS option I am able to exclude this directory from autodiscovery.
```bash
cat Makefile
```
```Makefile 
IGNORE_DIRS = $(SKETCH_DIR)libraries/pubsubclient/tests/*
include $(ESPMK_DIR)/makeEspArduino.mk
```

I can add multiple directories to IGNORE_DIRS by semicolon separator, i.e.:
```
IGNORE_DIRS = $(SKETCH_DIR)libraries/pubsubclient/tests/*;$(SKETCH_DIR)libraries/test
```